### PR TITLE
Update awsh version from 1.0.3 to 1.0.4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Merkle Manufactory
+Copyright 2024-2025 Merkle Manufactory
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Warpcast Homebrew Formulae
+# Merkle Manufactory Homebrew Formulae
 A collection of Homebrew formulae. Not recommended for external use.
 
 ## License

--- a/awsh.rb
+++ b/awsh.rb
@@ -1,10 +1,10 @@
 require 'formula'
 
-AWSH_VERSION = '1.0.3'
+AWSH_VERSION = '1.0.4'
 
 class Awsh < Formula
-  homepage 'https://github.com/warpcast/awsh'
-  url "https://github.com/warpcast/awsh/releases/download/v#{AWSH_VERSION}/awsh"
+  homepage 'https://github.com/merkle-team/awsh'
+  url "https://github.com/merkle-team/awsh/releases/download/v#{AWSH_VERSION}/awsh"
   sha256 "e9225c595b16a18e45e048ca5cbbe3d1d861ebc6195fe3403339072e7041f2d4"
 
   depends_on 'awscli'


### PR DESCRIPTION
Includes the GitHub org name update from `warpcast` to `merkle-team`.
